### PR TITLE
Fix ошибки запроса при использовании `get_all` с некоторыми методами

### DIFF
--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -117,7 +117,7 @@ class GetAllUserRequest(UserRequestAbstract):
         # будет рандомная и сущности будут повторяться на разных страницах
 
         # ряд методов не признают параметра "order", для таких ничего не делаем
-        excluded_methods = {"crm.address.list"}
+        excluded_methods = {"crm.address.list", "documentgenerator.template.list"}
 
         if self.method in excluded_methods:
             return


### PR DESCRIPTION
Убираем сортировку, которая вставляется внутри get_all по умолчанию, для метода `crm.address.list`

Fixes #151