### PR TITLE
Добавить в `call()` параметр `raw=True`

### DIFF
--- a/fast_bitrix24/__init__.py
+++ b/fast_bitrix24/__init__.py
@@ -1,3 +1,3 @@
-'''Высокоуровневый API для доступа к Битрикс24'''
+"""Высокоуровневый API для доступа к Битрикс24"""
 
 from fast_bitrix24.bitrix import Bitrix, BitrixAsync

--- a/fast_bitrix24/bitrix.py
+++ b/fast_bitrix24/bitrix.py
@@ -13,6 +13,7 @@ from .user_request import (
     GetAllUserRequest,
     GetByIDUserRequest,
     ListAndGetUserRequest,
+    RawCallUserRequest,
 )
 
 
@@ -136,7 +137,7 @@ class Bitrix(BitrixAbstract):
             ListAndGetUserRequest(self, method_branch, ID_field_name).run()
         )
 
-    def call(self, method: str, items: Union[dict, Iterable]):
+    def call(self, method: str, items: Union[dict, Iterable], /, raw=False):
         """
         Вызвать метод REST API по списку элементов.
 
@@ -144,12 +145,16 @@ class Bitrix(BitrixAbstract):
         - `method` - метод REST API
         - `items` - список параметров вызываемого метода
             либо dict с параметрами для единичного вызова
+        - `raw` - если True, то items отправляются на сервер в виде json
+            в первозданном виде, без обычных преобразований.
+            По умолчанию False.
 
         Возвращает список ответов сервера для каждого из элементов `items`
         либо просто результат для единичного вызова.
         """
 
-        return self.srh.run(CallUserRequest(self, method, items).run())
+        request_cls = RawCallUserRequest if raw else CallUserRequest
+        return self.srh.run(request_cls(self, method, items).run())
 
     def call_batch(self, params: dict) -> dict:
         """
@@ -279,7 +284,7 @@ class BitrixAsync(BitrixAbstract):
             self, method_branch, ID_field_name=ID_field_name
         ).run()
 
-    async def call(self, method: str, items: Union[dict, Iterable]):
+    async def call(self, method: str, items: Union[dict, Iterable], /, raw=False):
         """
         Вызвать метод REST API по списку элементов.
 
@@ -287,12 +292,16 @@ class BitrixAsync(BitrixAbstract):
         - `method` - метод REST API
         - `items` - список параметров вызываемого метода
             либо dict с параметрами для единичного вызова
+        - `raw` - если True, то items отправляются на сервер в виде json
+            в первозданном виде, без обычных преобразований.
+            По умолчанию False.
 
         Возвращает список ответов сервера для каждого из элементов `items`
         либо просто результат для единичного вызова.
         """
 
-        return await self.srh.run_async(CallUserRequest(self, method, items).run())
+        request_cls = RawCallUserRequest if raw else CallUserRequest
+        return await self.srh.run_async(request_cls(self, method, items).run())
 
     async def call_batch(self, params: dict) -> dict:
         """

--- a/fast_bitrix24/bitrix.py
+++ b/fast_bitrix24/bitrix.py
@@ -1,22 +1,30 @@
-'''Высокоуровневый API для доступа к Битрикс24'''
+"""Высокоуровневый API для доступа к Битрикс24"""
 
-import aiohttp
 from contextlib import asynccontextmanager, contextmanager
 from typing import Iterable, Union
 
+import aiohttp
+
 from . import correct_asyncio
 from .srh import ServerRequestHandler
-from .user_request import (BatchUserRequest, CallUserRequest,
-                           GetAllUserRequest, GetByIDUserRequest,
-                           ListAndGetUserRequest)
+from .user_request import (
+    BatchUserRequest,
+    CallUserRequest,
+    GetAllUserRequest,
+    GetByIDUserRequest,
+    ListAndGetUserRequest,
+)
 
 
 class BitrixAbstract(object):
-
-    def __init__(self, webhook: str, verbose: bool = True,
-                 respect_velocity_policy: bool = False,
-                 client: aiohttp.ClientSession = None):
-        '''
+    def __init__(
+        self,
+        webhook: str,
+        verbose: bool = True,
+        respect_velocity_policy: bool = False,
+        client: aiohttp.ClientSession = None,
+    ):
+        """
         Создает объект класса Bitrix.
 
         Параметры:
@@ -28,17 +36,17 @@ class BitrixAbstract(object):
         - `client: aiohttp.ClientSession = None` - использовать для HTTP-вызовов
         объект aiohttp.ClientSession, инициализированнный и настроенный
         пользователем.
-        '''
+        """
 
         self.srh = ServerRequestHandler(webhook, respect_velocity_policy, client)
         self.verbose = verbose
 
 
 class Bitrix(BitrixAbstract):
-    '''Клиент для запросов к серверу Битрикс24.'''
+    """Клиент для запросов к серверу Битрикс24."""
 
     def get_all(self, method: str, params: dict = None) -> Union[list, dict]:
-        '''
+        """
         Получить полный список сущностей по запросу `method`.
 
         Под капотом использует параллельные запросы и автоматическое построение
@@ -53,13 +61,18 @@ class Bitrix(BitrixAbstract):
 
         Возвращает полный список сущностей, имеющихся на сервере,
         согласно заданным методу и параметрам.
-        '''
+        """
 
         return self.srh.run(GetAllUserRequest(self, method, params).run())
 
-    def get_by_ID(self, method: str, ID_list: Iterable,
-                  ID_field_name: str = 'ID', params: dict = None) -> dict:
-        '''
+    def get_by_ID(
+        self,
+        method: str,
+        ID_list: Iterable,
+        ID_field_name: str = "ID",
+        params: dict = None,
+    ) -> dict:
+        """
         Получить список сущностей по запросу method и списку ID.
 
         Используется для случаев, когда нужны не все сущности,
@@ -87,13 +100,14 @@ class Bitrix(BitrixAbstract):
         относительно этого ID. Это может быть, например, список связанных
         сущностей или пустой список, если не найдено ни одной привязанной
         сущности.
-        '''
+        """
 
-        return self.srh.run(GetByIDUserRequest(
-            self, method, params, ID_list, ID_field_name).run())
+        return self.srh.run(
+            GetByIDUserRequest(self, method, params, ID_list, ID_field_name).run()
+        )
 
-    def list_and_get(self, method_branch: str, ID_field_name='ID') -> dict:
-        '''
+    def list_and_get(self, method_branch: str, ID_field_name="ID") -> dict:
+        """
         Скачать список всех ID при помощи метода *.list,
         а затем все элементы при помощи метода *.get.
 
@@ -116,13 +130,14 @@ class Bitrix(BitrixAbstract):
             ...
         }
         ```
-        '''
+        """
 
-        return self.srh.run(ListAndGetUserRequest(
-            self, method_branch, ID_field_name).run())
+        return self.srh.run(
+            ListAndGetUserRequest(self, method_branch, ID_field_name).run()
+        )
 
     def call(self, method: str, items: Union[dict, Iterable]):
-        '''
+        """
         Вызвать метод REST API по списку элементов.
 
         Параметры:
@@ -132,12 +147,12 @@ class Bitrix(BitrixAbstract):
 
         Возвращает список ответов сервера для каждого из элементов `items`
         либо просто результат для единичного вызова.
-        '''
+        """
 
         return self.srh.run(CallUserRequest(self, method, items).run())
 
     def call_batch(self, params: dict) -> dict:
-        '''
+        """
         Вызвать метод `batch`.
 
         Параметры:
@@ -145,22 +160,21 @@ class Bitrix(BitrixAbstract):
 
         Возвращает ответы сервера в формате словаря, где ключ - название
         команды, а значение - ответ сервера по этой команде.
-        '''
+        """
 
         return self.srh.run(BatchUserRequest(self, params).run())
 
     @contextmanager
     def slow(self, max_concurrent_requests: int = 1):
-        '''Временно ограничивает количество одновременно выполняемых запросов
-        к Битрикс24.'''
+        """Временно ограничивает количество одновременно выполняемых запросов
+        к Битрикс24."""
 
         if not isinstance(max_concurrent_requests, int):
-            raise 'slow() argument should be only int'
+            raise "slow() argument should be only int"
         if max_concurrent_requests < 1:
-            raise 'slow() argument should be >= 1'
+            raise "slow() argument should be >= 1"
 
-        mcr_max_backup, self.srh.mcr_max = \
-            self.srh.mcr_max, max_concurrent_requests
+        mcr_max_backup, self.srh.mcr_max = self.srh.mcr_max, max_concurrent_requests
         self.srh.mcr_cur_limit = min(self.srh.mcr_max, self.srh.mcr_cur_limit)
 
         yield True
@@ -170,12 +184,11 @@ class Bitrix(BitrixAbstract):
 
 
 class BitrixAsync(BitrixAbstract):
-    '''Класс, повторяющий интерфейс класса `Bitrix`,
-    но с асинхронными методами.'''
+    """Класс, повторяющий интерфейс класса `Bitrix`,
+    но с асинхронными методами."""
 
-    async def get_all(self, method: str, params: dict = None) -> \
-            Union[list, dict]:
-        '''
+    async def get_all(self, method: str, params: dict = None) -> Union[list, dict]:
+        """
         Получить полный список сущностей по запросу `method`.
 
         Под капотом использует параллельные запросы и автоматическое построение
@@ -191,15 +204,18 @@ class BitrixAsync(BitrixAbstract):
 
         Возвращает полный список сущностей, имеющихся на сервере,
         согласно заданным методу и параметрам.
-        '''
+        """
 
-        return await self.srh.run_async(
-            GetAllUserRequest(self, method, params).run())
+        return await self.srh.run_async(GetAllUserRequest(self, method, params).run())
 
-    async def get_by_ID(self, method: str, ID_list: Iterable,
-                        ID_field_name: str = 'ID',
-                        params: dict = None) -> list:
-        '''
+    async def get_by_ID(
+        self,
+        method: str,
+        ID_list: Iterable,
+        ID_field_name: str = "ID",
+        params: dict = None,
+    ) -> list:
+        """
         Получить список сущностей по запросу `method` и списку ID.
 
         Используется для случаев, когда нужны не все сущности,
@@ -227,14 +243,14 @@ class BitrixAsync(BitrixAbstract):
         относительно этого ID. Это может быть, например, список связанных
         сущностей или пустой список, если не найдено ни одной привязанной
         сущности.
-        '''
+        """
 
-        return await self.srh.run_async(GetByIDUserRequest(
-            self, method, params, ID_list, ID_field_name).run())
+        return await self.srh.run_async(
+            GetByIDUserRequest(self, method, params, ID_list, ID_field_name).run()
+        )
 
-    async def list_and_get(self, method_branch: str,
-                           ID_field_name='ID') -> dict:
-        '''
+    async def list_and_get(self, method_branch: str, ID_field_name="ID") -> dict:
+        """
         Скачать список всех ID при помощи метода *.list,
         а затем все элементы при помощи метода *.get.
 
@@ -257,13 +273,14 @@ class BitrixAsync(BitrixAbstract):
             ...
         }
         ```
-        '''
+        """
 
         return await ListAndGetUserRequest(
-            self, method_branch, ID_field_name=ID_field_name).run()
+            self, method_branch, ID_field_name=ID_field_name
+        ).run()
 
     async def call(self, method: str, items: Union[dict, Iterable]):
-        '''
+        """
         Вызвать метод REST API по списку элементов.
 
         Параметры:
@@ -273,13 +290,12 @@ class BitrixAsync(BitrixAbstract):
 
         Возвращает список ответов сервера для каждого из элементов `items`
         либо просто результат для единичного вызова.
-        '''
+        """
 
-        return await self.srh.run_async(
-            CallUserRequest(self, method, items).run())
+        return await self.srh.run_async(CallUserRequest(self, method, items).run())
 
     async def call_batch(self, params: dict) -> dict:
-        '''
+        """
         Вызвать метод `batch`.
 
         Параметры:
@@ -287,23 +303,21 @@ class BitrixAsync(BitrixAbstract):
 
         Возвращает ответы сервера в формате словаря, где ключ - название
         команды, а значение - ответ сервера по этой команде.
-        '''
+        """
 
-        return await self.srh.run_async(
-            BatchUserRequest(self, params).run())
+        return await self.srh.run_async(BatchUserRequest(self, params).run())
 
     @asynccontextmanager
     async def slow(self, max_concurrent_requests: int = 1):
-        '''Временно ограничивает количество одновременно выполняемых запросов
-        к Битрикс24.'''
+        """Временно ограничивает количество одновременно выполняемых запросов
+        к Битрикс24."""
 
         if not isinstance(max_concurrent_requests, int):
-            raise 'slow() argument should be only int'
+            raise "slow() argument should be only int"
         if max_concurrent_requests < 1:
-            raise 'slow() argument should be >= 1'
+            raise "slow() argument should be >= 1"
 
-        mcr_max_backup, self.srh.mcr_max = \
-            self.srh.mcr_max, max_concurrent_requests
+        mcr_max_backup, self.srh.mcr_max = self.srh.mcr_max, max_concurrent_requests
         self.srh.mcr_cur_limit = min(self.srh.mcr_max, self.srh.mcr_cur_limit)
 
         yield True

--- a/fast_bitrix24/correct_asyncio.py
+++ b/fast_bitrix24/correct_asyncio.py
@@ -1,4 +1,9 @@
-import sys, asyncio
+import asyncio
+import sys
 
-if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
+if (
+    sys.version_info[0] == 3
+    and sys.version_info[1] >= 8
+    and sys.platform.startswith("win")
+):
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())

--- a/fast_bitrix24/mult_request.py
+++ b/fast_bitrix24/mult_request.py
@@ -10,9 +10,9 @@ from .utils import http_build_query
 
 
 class MultipleServerRequestHandler:
-
-    def __init__(self, bitrix, method, item_list,
-                 real_len=None, real_start=0, mute=False):
+    def __init__(
+        self, bitrix, method, item_list, real_len=None, real_start=0, mute=False
+    ):
         self.bitrix = bitrix
         self.srh: ServerRequestHandler = bitrix.srh
         self.method = method
@@ -26,48 +26,50 @@ class MultipleServerRequestHandler:
         self.tasks = set()
 
     def generate_a_task(self):
-        '''Объединяем элементы item_list в батчи и по одной создаем и
-        возвращаем задачи asyncio с запросами к серверу для каждого батча.'''
+        """Объединяем элементы item_list в батчи и по одной создаем и
+        возвращаем задачи asyncio с запросами к серверу для каждого батча."""
 
-        batches = ({
-            'halt': 0,
-            'cmd': {
-                self.batch_command_label(i, item):
-                f'{self.method}?{http_build_query(item)}'
-                for i, item in enumerate(next_batch)
-            }}
-            for next_batch in chunked(self.item_list, BITRIX_MAX_BATCH_SIZE))
+        batches = (
+            {
+                "halt": 0,
+                "cmd": {
+                    self.batch_command_label(
+                        i, item
+                    ): f"{self.method}?{http_build_query(item)}"
+                    for i, item in enumerate(next_batch)
+                },
+            }
+            for next_batch in chunked(self.item_list, BITRIX_MAX_BATCH_SIZE)
+        )
 
         for batch in batches:
-            yield ensure_future(self.srh.single_request('batch', batch))
+            yield ensure_future(self.srh.single_request("batch", batch))
 
     def batch_command_label(self, i, item):
-        return f'cmd{i}'
+        return f"cmd{i}"
 
     async def run(self):
         self.top_up_tasks()
 
         with self.get_pbar() as pbar:
             while self.tasks:
-                done, self.tasks = await wait(self.tasks,
-                                              return_when=FIRST_COMPLETED)
+                done, self.tasks = await wait(self.tasks, return_when=FIRST_COMPLETED)
                 extracted_len = self.process_done_tasks(done)
                 pbar.update(extracted_len)
                 self.top_up_tasks()
 
-    #            self.pbar.set_postfix({
-    #                'max. requests': self.srh.mcr_cur_limit,
-    #                'requests': self.srh.concurrent_requests,
-    #                'tasks': len(self.tasks)})
+        #            self.pbar.set_postfix({
+        #                'max. requests': self.srh.mcr_cur_limit,
+        #                'requests': self.srh.concurrent_requests,
+        #                'tasks': len(self.tasks)})
 
         return self.results
 
     def top_up_tasks(self):
-        '''Добавляем в self.tasks столько задач, сколько свободных слотов для
-        запросов есть сейчас в self.srh.'''
+        """Добавляем в self.tasks столько задач, сколько свободных слотов для
+        запросов есть сейчас в self.srh."""
 
-        to_add = max(
-            int(self.srh.mcr_cur_limit) - self.srh.concurrent_requests, 0)
+        to_add = max(int(self.srh.mcr_cur_limit) - self.srh.concurrent_requests, 0)
         for _ in range(to_add):
             try:
                 self.tasks.add(next(self.task_iterator))
@@ -75,21 +77,20 @@ class MultipleServerRequestHandler:
                 break
 
     def process_done_tasks(self, done):
-        '''Извлечь результаты из списка законченных задач
-        и вернуть кол-во извлеченных элементов.'''
+        """Извлечь результаты из списка законченных задач
+        и вернуть кол-во извлеченных элементов."""
 
         extracted_len = 0
         for done_task in done:
             batch_response = done_task.result()
             unwrapped_result = ServerResponse(batch_response.result).result
-            extracted_len += self.extract_result_from_batch_response(
-                unwrapped_result)
+            extracted_len += self.extract_result_from_batch_response(unwrapped_result)
 
         return extracted_len
 
     def extract_result_from_batch_response(self, unwrapped_result):
-        '''Добавляет `unwrapped_result` в `self.results` и возвращает
-        длину добавленного списка результатов'''
+        """Добавляет `unwrapped_result` в `self.results` и возвращает
+        длину добавленного списка результатов"""
 
         if not unwrapped_result:
             return 0
@@ -101,17 +102,18 @@ class MultipleServerRequestHandler:
         return len(result_list)
 
     def get_pbar(self):
-        '''Возвращает прогресс бар `tqdm()` или пустышку,
-        если `self.bitrix.verbose is False`.'''
+        """Возвращает прогресс бар `tqdm()` или пустышку,
+        если `self.bitrix.verbose is False`."""
 
         if self.bitrix.verbose and not self.mute:
-            return tqdm(total=(self.real_len or len(self.item_list)),
-                        initial=self.real_start)
+            return tqdm(
+                total=(self.real_len or len(self.item_list)), initial=self.real_start
+            )
         else:
             return MutePBar()
 
 
-class MutePBar():
+class MutePBar:
     def __enter__(self):
         return self
 
@@ -123,7 +125,6 @@ class MutePBar():
 
 
 class MultipleServerRequestHandlerPreserveIDs(MultipleServerRequestHandler):
-
     def __init__(self, bitrix, method, item_list, ID_field):
         super().__init__(bitrix, method, item_list)
         self.ID_field = ID_field

--- a/fast_bitrix24/server_response.py
+++ b/fast_bitrix24/server_response.py
@@ -1,5 +1,7 @@
-class ServerResponse():
+import contextlib
 
+
+class ServerResponse:
     def __init__(self, response):
         self.response = response
         self.check_for_errors()
@@ -7,37 +9,30 @@ class ServerResponse():
     def check_for_errors(self):
         if self.result_error:
             raise RuntimeError(
-                f'The server reply contained an error: {self.result_error}')
+                f"The server reply contained an error: {self.result_error}"
+            )
 
     def __getattr__(self, item):
 
         # если результат вызова содержит только словарь {'tasks': список},
         # то вернуть этот список.
         # См. https://github.com/leshchenko1979/fast_bitrix24/issues/132
-        if item == 'result':
+        if item == "result":
 
             # для небатчевых запросов
-            try:
-                task_list = self.response['result']['tasks']
+            with contextlib.suppress(KeyError, TypeError):
+                task_list = self.response["result"]["tasks"]
                 if isinstance(task_list, list):
                     return task_list
-            except (KeyError, TypeError):
-                pass
 
             # для батчей
-            try:
-                return {batch_ID: batch_result['tasks']
-                        for batch_ID, batch_result
-                        in self.response['result'].items()}
-            except (KeyError, TypeError, AttributeError):
-                pass
+            with contextlib.suppress(KeyError, TypeError, AttributeError):
+                return {
+                    batch_ID: batch_result["tasks"]
+                    for batch_ID, batch_result in self.response["result"].items()
+                }
 
-        if item in self.response:
-            return self.response[item]
-
-        else:
-            return None
+        return self.response[item] if item in self.response else None
 
     def more_results_expected(self):
-        return self.total and self.total > 50 and \
-            self.total != len(self.result)
+        return self.total and self.total > 50 and self.total != len(self.result)

--- a/fast_bitrix24/srh.py
+++ b/fast_bitrix24/srh.py
@@ -131,7 +131,7 @@ class ServerRequestHandler:
             if not self.active_runs and self.session and not self.session.closed:
                 await self.session.close()
 
-    async def single_request(self, method, params=None):
+    async def single_request(self, method, params=None) -> ServerResponse:
         """Делает единичный запрос к серверу,
         с повторными попытками при необходимости."""
 
@@ -145,7 +145,7 @@ class ServerRequestHandler:
             except (ClientPayloadError, ServerDisconnectedError, ServerError) as err:
                 self.failure(err)
 
-    async def request_attempt(self, method, params=None):
+    async def request_attempt(self, method, params=None) -> ServerResponse:
         """Делает попытку запроса к серверу, ожидая при необходимости."""
 
         try:

--- a/fast_bitrix24/srh.py
+++ b/fast_bitrix24/srh.py
@@ -1,17 +1,18 @@
 import asyncio
-from asyncio import sleep, Event
 import time
+from asyncio import Event, sleep
 from collections import deque
 from contextlib import asynccontextmanager
 
 import aiohttp
-from aiohttp.client_exceptions import (ClientPayloadError, ClientResponseError,
-                                       ServerDisconnectedError)
-from tqdm import tqdm
+from aiohttp.client_exceptions import (
+    ClientPayloadError,
+    ClientResponseError,
+    ServerDisconnectedError,
+)
 
 from .server_response import ServerResponse
 from .utils import _url_valid
-
 
 BITRIX_POOL_SIZE = 50
 BITRIX_RPS = 2.0
@@ -32,8 +33,8 @@ class ServerError(Exception):
     pass
 
 
-class ServerRequestHandler():
-    '''
+class ServerRequestHandler:
+    """
     Используется для контроля скорости доступа к серверам Битрикс.
 
     Основная цель - вести учет количества запросов, которые можно передать
@@ -41,7 +42,7 @@ class ServerRequestHandler():
 
     Используется как контекстный менеджер, оборачивающий несколько
     последовательных запросов к серверу.
-    '''
+    """
 
     def __init__(self, webhook, respect_velocity_policy, client):
         self.webhook = self.standardize_webhook(webhook)
@@ -77,23 +78,23 @@ class ServerRequestHandler():
 
     @staticmethod
     def standardize_webhook(webhook):
-        '''Приводит `webhook` к стандартному виду.'''
+        """Приводит `webhook` к стандартному виду."""
 
         if not isinstance(webhook, str):
-            raise TypeError(f'Webhook should be a {str}')
+            raise TypeError(f"Webhook should be a {str}")
 
         webhook = webhook.strip()
 
         if not _url_valid(webhook):
-            raise ValueError('Webhook is not a valid URL')
+            raise ValueError("Webhook is not a valid URL")
 
-        if webhook[-1] != '/':
-            webhook += '/'
+        if webhook[-1] != "/":
+            webhook += "/"
 
         return webhook
 
     def run(self, coroutine):
-        '''Запускает `coroutine`, оборачивая его в `run_async()`.'''
+        """Запускает `coroutine`, оборачивая его в `run_async()`."""
 
         try:
             loop = asyncio.get_event_loop()
@@ -104,16 +105,16 @@ class ServerRequestHandler():
         return loop.run_until_complete(self.run_async(coroutine))
 
     async def run_async(self, coroutine):
-        '''Запускает `coroutine`, создавая и прекращая сессию
-        при необходимости.'''
+        """Запускает `coroutine`, создавая и прекращая сессию
+        при необходимости."""
 
         async with self.handle_sessions():
             return await coroutine
 
     @asynccontextmanager
     async def handle_sessions(self):
-        '''Открывает и закрывает сессию в зависимости от наличия
-        активных запросов.'''
+        """Открывает и закрывает сессию в зависимости от наличия
+        активных запросов."""
         if self.client_provided_by_user:
             yield True
             return
@@ -127,13 +128,12 @@ class ServerRequestHandler():
 
         finally:
             self.active_runs -= 1
-            if not self.active_runs and self.session and \
-                    not self.session.closed:
+            if not self.active_runs and self.session and not self.session.closed:
                 await self.session.close()
 
     async def single_request(self, method, params=None):
-        '''Делает единичный запрос к серверу,
-        с повторными попытками при необходимости.'''
+        """Делает единичный запрос к серверу,
+        с повторными попытками при необходимости."""
 
         while True:
 
@@ -142,42 +142,43 @@ class ServerRequestHandler():
                 self.success()
                 return result
 
-            except (ClientPayloadError,
-                    ServerDisconnectedError, ServerError) as err:
+            except (ClientPayloadError, ServerDisconnectedError, ServerError) as err:
                 self.failure(err)
 
     async def request_attempt(self, method, params=None):
-        '''Делает попытку запроса к серверу, ожидая при необходимости.'''
+        """Делает попытку запроса к серверу, ожидая при необходимости."""
 
         try:
             async with self.acquire(), self.session.post(
-                    url=self.webhook + method, json=params) as response:
-                return ServerResponse(await response.json(encoding='utf-8'))
+                url=self.webhook + method, json=params
+            ) as response:
+                return ServerResponse(await response.json(encoding="utf-8"))
 
         except ClientResponseError as error:
             if error.status // 100 == 5:  # ошибки вида 5XX
-                raise ServerError('The server returned an error') from error
+                raise ServerError("The server returned an error") from error
             else:
                 raise
 
     def success(self):
-        '''Увеличить счетчик удачных попыток.'''
+        """Увеличить счетчик удачных попыток."""
 
         self.successive_results = max(self.successive_results + 1, 1)
 
     def failure(self, err: Exception):
-        '''Увеличить счетчик неудачных попыток и поднять исключение,
-        если попытки исчерпаны.'''
+        """Увеличить счетчик неудачных попыток и поднять исключение,
+        если попытки исчерпаны."""
 
         self.successive_results = min(self.successive_results - 1, -1)
 
         if self.successive_results < -MAX_RETRIES:
             raise RuntimeError(
-                'All attempts to get data from server exhausted') from err
+                "All attempts to get data from server exhausted"
+            ) from err
 
     @asynccontextmanager
     async def acquire(self):
-        '''Ожидает, пока не станет безопасно делать запрос к серверу.'''
+        """Ожидает, пока не станет безопасно делать запрос к серверу."""
 
         await self.autothrottle()
 
@@ -189,27 +190,29 @@ class ServerRequestHandler():
                 yield
 
     async def autothrottle(self):
-        '''Если было несколько неудач, делаем таймаут и уменьшаем скорость
-        и количество одновременных запросов, и наоборот.'''
+        """Если было несколько неудач, делаем таймаут и уменьшаем скорость
+        и количество одновременных запросов, и наоборот."""
 
         if self.successive_results < 0:
 
             self.mcr_cur_limit = max(
-                self.mcr_cur_limit / DECREASE_CONNECTIONS_FACTOR, 1)
+                self.mcr_cur_limit / DECREASE_CONNECTIONS_FACTOR, 1
+            )
 
             if self.successive_results < NUM_FAILURES_NO_TIMEOUT:
                 power = -self.successive_results - NUM_FAILURES_NO_TIMEOUT - 1
-                await sleep(INITIAL_TIMEOUT * BACKOFF_FACTOR ** power)
+                await sleep(INITIAL_TIMEOUT * BACKOFF_FACTOR**power)
 
         elif self.successive_results > 0:
 
             self.mcr_cur_limit = min(
-                self.mcr_cur_limit * RESTORE_CONNECTIONS_FACTOR, self.mcr_max)
+                self.mcr_cur_limit * RESTORE_CONNECTIONS_FACTOR, self.mcr_max
+            )
 
     @asynccontextmanager
     async def limit_concurrent_requests(self):
-        '''Не позволяет оновременно выполнять
-        более `self.mcr_cur_limit` запросов.'''
+        """Не позволяет оновременно выполнять
+        более `self.mcr_cur_limit` запросов."""
 
         while self.concurrent_requests > self.mcr_cur_limit:
             self.request_complete.clear()
@@ -226,13 +229,12 @@ class ServerRequestHandler():
 
     @asynccontextmanager
     async def limit_request_velocity(self):
-        '''Ограничивает скорость запросов к серверу.'''
+        """Ограничивает скорость запросов к серверу."""
 
         # если пул заполнен, ждать
         while len(self.rr) >= self.pool_size:
             time_from_last_request = time.monotonic() - self.rr[0]
-            time_to_wait = 1 / self.requests_per_second - \
-                time_from_last_request
+            time_to_wait = 1 / self.requests_per_second - time_from_last_request
             if time_to_wait > 0:
                 await sleep(time_to_wait)
             else:

--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -287,7 +287,7 @@ class RawCallUserRequest(UserRequestAbstract):
 
     async def run(self):
         response = await self.srh.single_request(self.method, self.params)
-        return ServerResponse(response.result)
+        return response.result
 
 
 class BatchUserRequest(UserRequestAbstract):

--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -287,7 +287,7 @@ class RawCallUserRequest(UserRequestAbstract):
 
     async def run(self):
         response = await self.srh.single_request(self.method, self.params)
-        return ServerResponse(response.result).result
+        return ServerResponse(response.result)
 
 
 class BatchUserRequest(UserRequestAbstract):

--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -4,8 +4,10 @@ import warnings
 from collections import ChainMap
 from typing import Iterable
 
-from .mult_request import (MultipleServerRequestHandler,
-                           MultipleServerRequestHandlerPreserveIDs)
+from .mult_request import (
+    MultipleServerRequestHandler,
+    MultipleServerRequestHandlerPreserveIDs,
+)
 from .server_response import ServerResponse
 from .srh import ServerRequestHandler
 
@@ -13,9 +15,7 @@ BITRIX_PAGE_SIZE = 50
 
 
 class UserRequestAbstract(object):
-
-    def __init__(self, bitrix, method: str,
-                 params: dict = None, mute=False):
+    def __init__(self, bitrix, method: str, params: dict = None, mute=False):
         self.bitrix = bitrix
         self.srh: ServerRequestHandler = bitrix.srh
         self.method = method
@@ -27,16 +27,15 @@ class UserRequestAbstract(object):
 
     def standardized_method(self, method):
         if not method:
-            raise TypeError('Method cannot be empty')
+            raise TypeError("Method cannot be empty")
 
         if not isinstance(method, str):
-            raise TypeError('Method should be a str')
+            raise TypeError("Method should be a str")
 
         method = method.lower().strip()
 
-        if method == 'batch':
-            raise ValueError(
-                "Method cannot be 'batch'. Use call_batch() instead.")
+        if method == "batch":
+            raise ValueError("Method cannot be 'batch'. Use call_batch() instead.")
 
         return method
 
@@ -45,11 +44,11 @@ class UserRequestAbstract(object):
             return None
 
         if not isinstance(p, dict):
-            raise TypeError('Params agrument should be a dict')
+            raise TypeError("Params agrument should be a dict")
 
         for key, __ in p.items():
             if not isinstance(key, str):
-                raise TypeError('Keys in params argument should be strs')
+                raise TypeError("Keys in params argument should be strs")
 
         p = {key.upper().strip(): value for key, value in p.items()}
 
@@ -59,14 +58,14 @@ class UserRequestAbstract(object):
 
     def check_expected_clause_types(self, p):
         EXPECTED_TYPES = {
-            'SELECT': list,
-            'HELT': int,
-            'CMD': dict,
-            'LIMIT': int,
-            'ORDER': dict,
-            'FILTER': dict,
-            'START': int,
-            'FIELDS': dict
+            "SELECT": list,
+            "HELT": int,
+            "CMD": dict,
+            "LIMIT": int,
+            "ORDER": dict,
+            "FILTER": dict,
+            "START": int,
+            "FIELDS": dict,
         }
 
         # check for allowed types of key values
@@ -85,21 +84,22 @@ class UserRequestAbstract(object):
                 if not type_ok or list_error:
                     raise TypeError(
                         f'Clause "{clause_key}" should be '
-                        f'of type {expected_type}, '
-                        f'but its type is {type(clause_value)}')
+                        f"of type {expected_type}, "
+                        f"but its type is {type(clause_value)}"
+                    )
 
     def check_special_limitations(self):
         raise NotImplementedError
 
 
 class GetAllUserRequest(UserRequestAbstract):
-
     def check_special_limitations(self):
         if self.st_params and not set(self.st_params.keys()).isdisjoint(
-            {'START', 'LIMIT', 'ORDER'}
+            {"START", "LIMIT", "ORDER"}
         ):
-            raise ValueError("get_all() doesn't support parameters "
-                             "'start', 'limit' or 'order'")
+            raise ValueError(
+                "get_all() doesn't support parameters " "'start', 'limit' or 'order'"
+            )
 
     async def run(self):
         self.add_order_parameter()
@@ -122,33 +122,31 @@ class GetAllUserRequest(UserRequestAbstract):
         if self.method in excluded_methods:
             return
 
-        order_clause = {'order': {'ID': 'ASC'}}
+        order_clause = {"order": {"ID": "ASC"}}
 
         if self.params:
-            if 'ORDER' not in self.st_params:
+            if "ORDER" not in self.st_params:
                 self.params.update(order_clause)
         else:
             self.params = order_clause
 
     async def make_first_request(self):
-        self.first_response = await self.srh.single_request(
-            self.method, self.params)
-        self.results, self.total = \
-            self.first_response.result, self.first_response.total
+        self.first_response = await self.srh.single_request(self.method, self.params)
+        self.results, self.total = self.first_response.result, self.first_response.total
 
     async def make_remaining_requests(self):
         item_list = (
-            ChainMap({'start': start}, self.params)
+            ChainMap({"start": start}, self.params)
             for start in range(len(self.results), self.total, BITRIX_PAGE_SIZE)
         )
         remaining_results = await MultipleServerRequestHandler(
-                self.bitrix,
-                method=self.method,
-                item_list=item_list,
-                real_len=self.total,
-                real_start=len(self.results),
-                mute=self.mute
-            ).run()
+            self.bitrix,
+            method=self.method,
+            item_list=item_list,
+            real_len=self.total,
+            real_start=len(self.results),
+            mute=self.mute,
+        ).run()
 
         self.results.extend(remaining_results)
 
@@ -164,21 +162,24 @@ class GetAllUserRequest(UserRequestAbstract):
             warnings.warn(
                 f"Number of results returned ({len(self.results)}) "
                 f"doesn't equal 'total' from the server reply ({self.total})",
-                RuntimeWarning)
+                RuntimeWarning,
+            )
 
 
 class GetByIDUserRequest(UserRequestAbstract):
-
-    def __init__(self, bitrix, method: str, params: dict,
-                 ID_list: Iterable, ID_field_name: str):
+    def __init__(
+        self, bitrix, method: str, params: dict, ID_list: Iterable, ID_field_name: str
+    ):
         self.ID_list = ID_list
         self.ID_field_name = ID_field_name.strip()
         super().__init__(bitrix, method, params)
 
     def check_special_limitations(self):
-        if self.st_params and 'ID' in self.st_params.keys():
-            raise ValueError("get_by_ID() doesn't support parameter 'ID' "
-                             "within the 'params' argument")
+        if self.st_params and "ID" in self.st_params.keys():
+            raise ValueError(
+                "get_by_ID() doesn't support parameter 'ID' "
+                "within the 'params' argument"
+            )
 
         try:
             iter(self.ID_list)
@@ -189,23 +190,23 @@ class GetByIDUserRequest(UserRequestAbstract):
             try:
                 len(self.ID_list)
             except TypeError:
-                raise TypeError("get_by_ID(): 'ID_list' should be a Sequence "
-                                "if a progress bar is to be displayed")
+                raise TypeError(
+                    "get_by_ID(): 'ID_list' should be a Sequence "
+                    "if a progress bar is to be displayed"
+                )
 
         for ID in self.ID_list:
             if not isinstance(ID, (str, int)):
                 raise TypeError(
-                    "get_by_ID(): 'ID_list' should contain only ints or strs")
+                    "get_by_ID(): 'ID_list' should contain only ints or strs"
+                )
 
     async def run(self) -> dict:
 
         self.prepare_item_list()
 
         results = await MultipleServerRequestHandlerPreserveIDs(
-            self.bitrix,
-            self.method,
-            self.item_list,
-            ID_field=self.ID_field_name
+            self.bitrix, self.method, self.item_list, ID_field=self.ID_field_name
         ).run()
 
         return results
@@ -213,39 +214,38 @@ class GetByIDUserRequest(UserRequestAbstract):
     def prepare_item_list(self):
         if self.params:
             self.item_list = [
-                ChainMap({self.ID_field_name: ID}, self.params)
-                for ID in self.ID_list
+                ChainMap({self.ID_field_name: ID}, self.params) for ID in self.ID_list
             ]
         else:
-            self.item_list = [
-                {self.ID_field_name: ID}
-                for ID in self.ID_list
-            ]
+            self.item_list = [{self.ID_field_name: ID} for ID in self.ID_list]
 
 
 class CallUserRequest(GetByIDUserRequest):
-
-    def __init__(self, bitrix, method: str,
-                 item_list: Iterable):
+    def __init__(self, bitrix, method: str, item_list: Iterable):
         self.item_list = item_list
-        super().__init__(bitrix, method, None, None, '__order')
+        super().__init__(bitrix, method, None, None, "__order")
 
     def check_special_limitations(self):
         try:
-            if not (isinstance(self.item_list, dict) or
-                    all(isinstance(item, dict) for item in self.item_list)):
+            if not (
+                isinstance(self.item_list, dict)
+                or all(isinstance(item, dict) for item in self.item_list)
+            ):
                 raise TypeError
         except TypeError:
             raise TypeError(
-                'call() accepts either an iterable of params dicts or '
-                'a single params dict')
+                "call() accepts either an iterable of params dicts or "
+                "a single params dict"
+            )
 
         if self.bitrix.verbose:
             try:
                 len(self.item_list)
             except TypeError:
-                raise TypeError("call(): 'items' should be a Sequence "
-                                "if a progress bar is to be displayed")
+                raise TypeError(
+                    "call(): 'items' should be a Sequence "
+                    "if a progress bar is to be displayed"
+                )
 
     async def run(self):
 
@@ -260,29 +260,29 @@ class CallUserRequest(GetByIDUserRequest):
     def prepare_item_list(self):
         # добавим порядковый номер
         self.item_list = [
-            ChainMap(item, {self.ID_field_name: 'order' + str(i)})
+            ChainMap(item, {self.ID_field_name: f"order{str(i)}"})
             for i, item in enumerate(self.item_list)
         ]
 
 
 class BatchUserRequest(UserRequestAbstract):
-
     def __init__(self, bitrix, params):
-        super().__init__(bitrix, 'batch', params)
+        super().__init__(bitrix, "batch", params)
 
     def standardized_method(self, method):
-        return 'batch'
+        return "batch"
 
     def check_special_limitations(self):
         if not self.st_params:
             raise ValueError("Params for a batch call can't be empty")
 
-        if {'HALT', 'CMD'} != self.st_params.keys():
+        if {"HALT", "CMD"} != self.st_params.keys():
             raise ValueError(
                 "Params for a batch call should contain only 'halt' and 'cmd' "
-                "clauses at the highest level")
+                "clauses at the highest level"
+            )
 
-        if not isinstance(self.st_params['CMD'], dict):
+        if not isinstance(self.st_params["CMD"], dict):
             raise ValueError("'cmd' clause should contain a dict")
 
     async def run(self):
@@ -291,8 +291,7 @@ class BatchUserRequest(UserRequestAbstract):
 
 
 class ListAndGetUserRequest(object):
-
-    def __init__(self, bitrix, method_branch, ID_field_name='ID'):
+    def __init__(self, bitrix, method_branch, ID_field_name="ID"):
         self.bitrix = bitrix
         self.srh: ServerRequestHandler = bitrix.srh
         self.method_branch = method_branch
@@ -302,25 +301,32 @@ class ListAndGetUserRequest(object):
         if not isinstance(self.method_branch, str):
             raise TypeError('"method_branch" should be a str')
 
-        if re.search(r'(\.list|\.get)$', self.method_branch.strip().lower()):
-            raise ValueError(
-                '"method_branch" should not end in ".list" or ".get"')
+        if re.search(r"(\.list|\.get)$", self.method_branch.strip().lower()):
+            raise ValueError('"method_branch" should not end in ".list" or ".get"')
 
-        IDs = await self.srh.run_async(GetAllUserRequest(
-            self.bitrix,
-            self.method_branch + '.list',
-            params={'select': [self.ID_field_name]},
-            mute=True).run())
+        IDs = await self.srh.run_async(
+            GetAllUserRequest(
+                self.bitrix,
+                f"{self.method_branch}.list",
+                params={"select": [self.ID_field_name]},
+                mute=True,
+            ).run()
+        )
 
         try:
             ID_list = [x[self.ID_field_name] for x in IDs]
         except (TypeError, KeyError):
-            raise ValueError('Seems like list_and_get() cannot be used '
-                             f'with method branch "{self.method_branch}"')
+            raise ValueError(
+                "Seems like list_and_get() cannot be used "
+                f'with method branch "{self.method_branch}"'
+            )
 
-        return await self.srh.run_async(GetByIDUserRequest(
-            bitrix=self.bitrix,
-            method=self.method_branch + '.get',
-            params=None,
-            ID_field_name=self.ID_field_name,
-            ID_list=ID_list).run())
+        return await self.srh.run_async(
+            GetByIDUserRequest(
+                bitrix=self.bitrix,
+                method=f"{self.method_branch}.get",
+                params=None,
+                ID_field_name=self.ID_field_name,
+                ID_list=ID_list,
+            ).run()
+        )

--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -265,6 +265,27 @@ class CallUserRequest(GetByIDUserRequest):
         ]
 
 
+class RawCallUserRequest(UserRequestAbstract):
+    """Отправляем на сервер один элемент, не обрабатывая его и не заворачивая в батчи.
+
+    Нужно для устревших методов, которые принимают на вход список
+    (https://github.com/leshchenko1979/fast_bitrix24/issues/157),
+    а также для отправки на сервер значений None, которые преобразуются
+    в строку при заворачивании в батч
+    (https://github.com/leshchenko1979/fast_bitrix24/issues/156).
+    """
+    def __init__(self, bitrix, method: str, item: dict):
+        super().__init__(bitrix, method, item)
+
+    def standardized_params(self, p):
+        """Пропускаем все проверки и изменения параметров."""
+        return p
+
+    async def run(self):
+        response = await self.srh.single_request(self.method, self.params)
+        return ServerResponse(response.result).result
+
+
 class BatchUserRequest(UserRequestAbstract):
     def __init__(self, bitrix, params):
         super().__init__(bitrix, "batch", params)

--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -274,12 +274,16 @@ class RawCallUserRequest(UserRequestAbstract):
     в строку при заворачивании в батч
     (https://github.com/leshchenko1979/fast_bitrix24/issues/156).
     """
+
     def __init__(self, bitrix, method: str, item: dict):
         super().__init__(bitrix, method, item)
 
     def standardized_params(self, p):
         """Пропускаем все проверки и изменения параметров."""
         return p
+
+    def check_special_limitations(self):
+        pass
 
     async def run(self):
         response = await self.srh.single_request(self.method, self.params)

--- a/fast_bitrix24/utils.py
+++ b/fast_bitrix24/utils.py
@@ -1,5 +1,3 @@
-from functools import wraps
-from time import sleep
 from urllib.parse import quote, urlparse
 
 
@@ -24,11 +22,9 @@ def http_build_query(params, convention="%s"):
 
         elif type(params[key]) is list:
 
-            new_params = {str(i): element for i, element
-                          in enumerate(params[key])}
+            new_params = {str(i): element for i, element in enumerate(params[key])}
 
-            output += http_build_query(
-                new_params, convention % key + "[%s]")
+            output += http_build_query(new_params, convention % key + "[%s]")
 
         else:
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,55 @@
+from fast_bitrix24.server_response import ServerResponse
+from fast_bitrix24.utils import http_build_query
+
+
+def test_server_response():
+    RAW = {
+        "result": 25,
+        "time": {
+            "start": 1649929692.302662,
+            "finish": 1649929692.547846,
+            "duration": 0.24518418312072754,
+            "processing": 0.14425015449523926,
+            "date_start": "2022-04-14T12:48:12+03:00",
+            "date_finish": "2022-04-14T12:48:12+03:00",
+        },
+    }
+    assert ServerResponse(RAW).result == 25
+
+
+class TestHttpBuildQuery:
+    def test_original(self):
+        assert http_build_query({"alpha": "bravo"}) == "alpha=bravo&"
+
+        test = http_build_query({"charlie": ["delta", "echo", "foxtrot"]})
+        assert "charlie[0]=delta" in test
+        assert "charlie[1]=echo" in test
+        assert "charlie[2]=foxtrot" in test
+
+        test = http_build_query(
+            {
+                "golf": [
+                    "hotel",
+                    {"india": "juliet", "kilo": ["lima", "mike"]},
+                    "november",
+                    "oscar",
+                ]
+            }
+        )
+        assert "golf[0]=hotel" in test
+        assert "golf[1][india]=juliet" in test
+        assert "golf[1][kilo][0]=lima" in test
+        assert "golf[1][kilo][1]=mike" in test
+        assert "golf[2]=november" in test
+        assert "golf[3]=oscar" in test
+
+    def test_new(self):
+        d = {"FILTER": {"STATUS_ID": "CLOSED"}}
+
+        test = http_build_query(d)
+        assert test == "FILTER[STATUS_ID]=CLOSED&"
+
+        d = {"FILTER": {"!STATUS_ID": "CLOSED"}}
+
+        test = http_build_query(d)
+        assert test == "FILTER[%21STATUS_ID]=CLOSED&"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,6 +1,5 @@
 import pytest
 
-from fast_bitrix24.utils import http_build_query
 from .fixtures import (create_100_leads, create_100_leads_async, create_a_lead,
                        get_test, get_test_async, create_a_deal,
                        create_100_tasks)
@@ -269,47 +268,3 @@ class TestParamsEncoding:
                              {'ID': lead_no})
 
         assert len(product_rows) == len(result_rows)
-
-
-class TestHttpBuildQuery:
-
-    def test_original(self):
-        assert http_build_query({"alpha": "bravo"}) == "alpha=bravo&"
-
-        test = http_build_query({"charlie": ["delta", "echo", "foxtrot"]})
-        assert "charlie[0]=delta" in test
-        assert "charlie[1]=echo" in test
-        assert "charlie[2]=foxtrot" in test
-
-        test = http_build_query({
-            "golf": [
-                "hotel",
-                {"india": "juliet", "kilo": ["lima", "mike"]},
-                "november", "oscar"
-            ]
-        })
-        assert "golf[0]=hotel" in test
-        assert "golf[1][india]=juliet" in test
-        assert "golf[1][kilo][0]=lima" in test
-        assert "golf[1][kilo][1]=mike" in test
-        assert "golf[2]=november" in test
-        assert "golf[3]=oscar" in test
-
-    def test_new(self):
-        d = {
-            'FILTER': {
-                'STATUS_ID': 'CLOSED'
-            }
-        }
-
-        test = http_build_query(d)
-        assert test == 'FILTER[STATUS_ID]=CLOSED&'
-
-        d = {
-            'FILTER': {
-                '!STATUS_ID': 'CLOSED'
-            }
-        }
-
-        test = http_build_query(d)
-        assert test == 'FILTER[%21STATUS_ID]=CLOSED&'


### PR DESCRIPTION
Указание этого параметра предотвращает обработку передаваемых данных, включая заворачивание передаваемого элемента в батч.