### PR TITLE
Создавать копию объекта params в UserRequestAbstract

### DIFF
--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -52,7 +52,7 @@ class UserRequestAbstract:
 
         # st_params будет использоваться для проверки параметров,
         # но на сервер должны уходить параметры без изменения регистра
-        self.params = params.copy()
+        self.params = params.copy() if params else {}
         self.st_params = self.standardized_params(params)
 
         self.mute = mute

--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -52,7 +52,7 @@ class UserRequestAbstract:
 
         # st_params будет использоваться для проверки параметров,
         # но на сервер должны уходить параметры без изменения регистра
-        self.params = params
+        self.params = params.copy()
         self.st_params = self.standardized_params(params)
 
         self.mute = mute


### PR DESCRIPTION
Fixes #238

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug by ensuring that the 'params' object is copied in the 'UserRequestAbstract' class to prevent unintended modifications to the original object.

- **Bug Fixes**:
    - Fixed an issue where the original 'params' object could be unintentionally modified by creating a copy of it in the 'UserRequestAbstract' class.

<!-- Generated by sourcery-ai[bot]: end summary -->