### PR TITLE
Проблема с добавлением полей для сортировки в запрос

### DIFF
--- a/fast_bitrix24/user_request.py
+++ b/fast_bitrix24/user_request.py
@@ -187,6 +187,9 @@ class GetAllUserRequest(UserRequestAbstract):
             "crm.address.list",
             "documentgenerator.template.list",
             "userfieldconfig.list",
+            "voximplant.statistic.get",
+            "crm.deal.userfield.list",
+            "task.elapseditem.getlist"
         }
 
         if self.st_method in EXCLUDED_METHODS:


### PR DESCRIPTION
Fixes #98

## Сводка от Sourcery

Исправления ошибок:
- Исправлена проблема №98: Добавлена возможность добавления полей сортировки в запросы для методов `voximplant.statistic.get`, `crm.deal.userfield.list` и `task.elapseditem.getlist`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix issue #98: Allow adding sorting fields to queries for methods `voximplant.statistic.get`, `crm.deal.userfield.list`, and `task.elapseditem.getlist`.

</details>