### PR TITLE
crm.company.contact.items.get возвращает только один элемент, а нужно несколько

### DIFF
--- a/fast_bitrix24/server_response.py
+++ b/fast_bitrix24/server_response.py
@@ -52,7 +52,11 @@ class ServerResponseParser:
 
         extracted = self.extract_from_single_response(self.result["result"])
 
-        return extracted[0] if isinstance(extracted, list) else extracted
+        return (
+            extracted[0]
+            if isinstance(extracted, list) and len(extracted) == 1
+            else extracted
+        )
 
     def raise_for_errors(self):
         errors = self.extract_errors()
@@ -86,7 +90,7 @@ class ServerResponseParser:
 
     @staticmethod
     def is_nested(result) -> bool:
-        return isinstance(result, (dict, list)) and len(result) == 1
+        return isinstance(result, dict) and len(result.values()) == 1
 
     def extract_from_batch_response(self, result) -> list:
         if not result:

--- a/tests/real_responses/crm_company_contact_items_get.py
+++ b/tests/real_responses/crm_company_contact_items_get.py
@@ -1,0 +1,35 @@
+response = {
+    "result": {
+        "result": {
+            "205364": [
+                {"CONTACT_ID": 350354, "SORT": 10, "ROLE_ID": 0, "IS_PRIMARY": "Y"},
+                {"CONTACT_ID": 369658, "SORT": 10, "ROLE_ID": 0, "IS_PRIMARY": "Y"},
+            ]
+        },
+        "result_error": [],
+        "result_total": [],
+        "result_next": [],
+        "result_time": {
+            "205364": {
+                "start": 1739205151.785116,
+                "finish": 1739205151.915156,
+                "duration": 0.13003993034362793,
+                "processing": 0.12938594818115234,
+                "date_start": "2025-02-10T19:32:31+03:00",
+                "date_finish": "2025-02-10T19:32:31+03:00",
+                "operating_reset_at": 1739205751,
+                "operating": 0.7021360397338867,
+            }
+        },
+    },
+    "time": {
+        "start": 1739205151.753569,
+        "finish": 1739205151.916085,
+        "duration": 0.16251611709594727,
+        "processing": 0.13108110427856445,
+        "date_start": "2025-02-10T19:32:31+03:00",
+        "date_finish": "2025-02-10T19:32:31+03:00",
+        "operating_reset_at": 1739205751,
+        "operating": 0,
+    },
+}

--- a/tests/test_server_responses.py
+++ b/tests/test_server_responses.py
@@ -311,12 +311,10 @@ def test_crm_contact_add_batch(bx_dummy):
                 "NAME": "TESTR",
                 "PHONE": [{"VALUE": "78966666647", "VALUE_TYPE": "WORK"}],
                 "ASSIGNED_BY_ID": -1,
-                "OPENED": "Y"
+                "OPENED": "Y",
             },
-            "params": {
-                "REGISTER_SONET_EVENT": "Y"
-            }
-        }
+            "params": {"REGISTER_SONET_EVENT": "Y"},
+        },
     )
 
     # Проверяем что результат - это ID созданного контакта
@@ -325,39 +323,47 @@ def test_crm_contact_add_batch(bx_dummy):
 
 def test_crm_contact_list(bx_dummy):
     response = {
-        'result': [
+        "result": [
             {
-                'ID': '10',
-                'NAME': 'Абдуалимова Татьяна Александровна',
-                'SECOND_NAME': None,
-                'LAST_NAME': None
+                "ID": "10",
+                "NAME": "Абдуалимова Татьяна Александровна",
+                "SECOND_NAME": None,
+                "LAST_NAME": None,
             }
         ],
-        'total': 1,
-        'time': {
-            'start': 1731743829.0188,
-            'finish': 1731743829.06444,
-            'duration': 0.045639991760253906,
-            'processing': 0.019975900650024414,
-            'date_start': '2024-11-16T10:57:09+03:00',
-            'date_finish': '2024-11-16T10:57:09+03:00',
-            'operating_reset_at': 1731744429,
-            'operating': 0
-        }
+        "total": 1,
+        "time": {
+            "start": 1731743829.0188,
+            "finish": 1731743829.06444,
+            "duration": 0.045639991760253906,
+            "processing": 0.019975900650024414,
+            "date_start": "2024-11-16T10:57:09+03:00",
+            "date_finish": "2024-11-16T10:57:09+03:00",
+            "operating_reset_at": 1731744429,
+            "operating": 0,
+        },
     }
 
     bx_dummy.srh = MockSRH(response)
     results = bx_dummy.get_all(
-        'crm.contact.list',
+        "crm.contact.list",
         {
-            'params': {
-                'select': ['ID', 'NAME', 'SECOND_NAME', 'LAST_NAME'],
-                'filter': {'=ID': ['10']}
+            "params": {
+                "select": ["ID", "NAME", "SECOND_NAME", "LAST_NAME"],
+                "filter": {"=ID": ["10"]},
             }
-        }
+        },
     )
 
     assert isinstance(results, list)
     assert len(results) == 1
-    assert results[0]['ID'] == '10'
-    assert results[0]['NAME'] == 'Абдуалимова Татьяна Александровна'
+    assert results[0]["ID"] == "10"
+    assert results[0]["NAME"] == "Абдуалимова Татьяна Александровна"
+
+
+def test_crm_company_contact_items_get(bx_dummy):
+    from tests.real_responses.crm_company_contact_items_get import response
+
+    bx_dummy.srh = MockSRH(response)
+    results = bx_dummy.get_by_ID("crm.company.contact.items.get", ["205364"])
+    assert len(results) == 2


### PR DESCRIPTION
Fixes #256

## Обзор от Sourcery

Исправления ошибок:
- Исправлена проблема, когда `crm.company.contact.items.get` возвращал только один элемент, хотя ожидалось несколько.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix an issue where `crm.company.contact.items.get` was returning only one item when multiple items were expected.

</details>