### PR TITLE
tests: convert create_100_leads_async into pytest-asyncio fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import pytest_asyncio
 
 from fast_bitrix24 import Bitrix, BitrixAsync
 
@@ -109,8 +110,7 @@ def create_100_tasks(get_test) -> Bitrix:
                     ID_field_name='taskId')
 
 
-@pytest.fixture(scope='function')
-@pytest.mark.asyncio
+@pytest_asyncio.fixture
 async def create_100_leads_async(get_test_async) -> BitrixAsync:
     b = get_test_async
 


### PR DESCRIPTION
Running tests suite against `pytest` 9 fails with:
```
INFO     : Running command: ['python3', '-m', 'pytest', '-vra', 'tests']
ImportError while loading conftest '/usr/src/RPM/BUILD/python3-module-fast-bitrix24-1.7.4/tests/conftest.py'.
tests/conftest.py:112: in <module>
    @pytest.fixture(scope='function')
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   pytest.PytestRemovedIn9Warning: Marks applied to fixtures have no effect
E   See docs: https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function
```

According to `pytest` docs:
https://docs.pytest.org/en/stable/deprecations.html#applying-a-mark-to-a-fixture-function

> Applying a mark to a fixture function never had any effect

`pytest-asyncio` docs:
https://pytest-asyncio.readthedocs.io/en/latest/reference/decorators/index.html

> auto mode automatically converts coroutines and async generator
  functions declared with the standard @pytest.fixture decorator to
  pytest-asyncio fixtures.

Fixes: https://github.com/leshchenko1979/fast_bitrix24/issues/266

## Summary by Sourcery

Исправления ошибок:
- Исправлена асинхронная фикстура создания лида, чтобы избежать устаревших `pytest`-меток для фикстур в `pytest 9`.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix async lead creation fixture definition to avoid deprecated pytest marks on fixtures under pytest 9.

</details>